### PR TITLE
Cleanup and ZenovaAPI permissions

### DIFF
--- a/ZenovaLauncher/App.xaml.cs
+++ b/ZenovaLauncher/App.xaml.cs
@@ -17,7 +17,8 @@ namespace ZenovaLauncher
         private readonly string _environmentKey = "ZENOVA_DATA";
         private readonly string _directoryMods = "mods";
         private readonly string _directoryVersions = "versions";
-        private string _dataDirectory;
+
+        public static string DataDirectory { get; private set; }
 
         private const string AppID = "ZenovaApplicationID";
 
@@ -144,34 +145,25 @@ namespace ZenovaLauncher
             string value = Environment.GetEnvironmentVariable(_environmentKey, EnvironmentVariableTarget.User);
             if (value != null)
             {
-                _dataDirectory = value;
+                DataDirectory = value;
             }
             else
             {
                 value = Environment.GetEnvironmentVariable(_environmentKey, EnvironmentVariableTarget.Machine);
                 if (value != null)
                 {
-                    _dataDirectory = value;
+                    DataDirectory = value;
                 }
                 else
                 {
+                    // setup default location
+                    DataDirectory = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "Zenova");
+                    foreach (string path in Directory.EnumerateFiles(DataDirectory))
+                        Utils.AddSecurityToFile(path);
+
                     // if not, create user environment variable at default location
                     Environment.SetEnvironmentVariable(_environmentKey, DataDirectory, EnvironmentVariableTarget.User);
                 }
-            }
-        }
-
-        public string DataDirectory
-        {
-            get
-            {
-                if (_dataDirectory == null)
-                {
-                    _dataDirectory = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "Zenova");
-                    foreach (string path in Directory.EnumerateFiles(_dataDirectory))
-                        Utils.AddSecurityToFile(path);
-                }
-                return _dataDirectory;
             }
         }
 

--- a/ZenovaLauncher/App.xaml.cs
+++ b/ZenovaLauncher/App.xaml.cs
@@ -73,7 +73,7 @@ namespace ZenovaLauncher
                 SetupEnvironment();
                 Trace.Listeners.Add(new TextWriterTraceListener(new FileStream(Path.Combine(DataDirectory, "log.txt"), FileMode.Create)));
                 Trace.AutoFlush = true;
-                ZenovaUpdater.instance = new ZenovaUpdater(DataDirectory);
+                ZenovaUpdater.instance = new ZenovaUpdater();
                 Trace.WriteLine("ZenovaUpdater.instance " + sw.ElapsedMilliseconds + " ms");
                 VersionDownloader.standard = new VersionDownloader();
                 Trace.WriteLine("VersionDownloader.standard " + sw.ElapsedMilliseconds + " ms");
@@ -97,7 +97,7 @@ namespace ZenovaLauncher
                 Trace.WriteLine("ModManager.LoadMods " + sw.ElapsedMilliseconds + " ms");
                 ProfileManager.instance.ImportProfiles();
                 Trace.WriteLine("ProfileManager.ImportProfiles " + sw.ElapsedMilliseconds + " ms");
-                Preferences.LoadPreferences(DataDirectory);
+                Preferences.LoadPreferences();
                 Trace.WriteLine("Preferences.LoadPreferences " + sw.ElapsedMilliseconds + " ms");
                 VersionManager.instance.RemoveUnusedVersions();
                 Trace.WriteLine("VersionManager.RemoveUnusedVersions " + sw.ElapsedMilliseconds + " ms");

--- a/ZenovaLauncher/Profiles/ProfileLauncher.cs
+++ b/ZenovaLauncher/Profiles/ProfileLauncher.cs
@@ -106,6 +106,9 @@ namespace ZenovaLauncher
                 }
                 if (p.Modded)
                 {
+                    // Ensure ZenovaAPI.dll has ALL APPLICATION PACKAGES security
+                    Utils.AddSecurityToFile(Path.Combine(App.DataDirectory, "ZenovaAPI.dll"));
+
                     AppDebugger app = new AppDebugger(Utils.FindPackages(p.Version.PackageFamily).ToList()[0].Id.FullName);
                     if (app.GetPackageExecutionState() != PACKAGE_EXECUTION_STATE.PES_UNKNOWN)
                     {

--- a/ZenovaLauncher/Profiles/ProfileManager.cs
+++ b/ZenovaLauncher/Profiles/ProfileManager.cs
@@ -14,7 +14,8 @@ namespace ZenovaLauncher
         public static ProfileManager instance;
         private static JsonSerializerSettings jsonSettings;
 
-        private readonly string _profilesFile = "profiles.json";
+        private readonly string _profilesFileName = "profiles.json";
+        private string ProfilesFile;
 
         public Action Refresh { get; set; }
         public string ProfilesDir { get; }
@@ -24,6 +25,7 @@ namespace ZenovaLauncher
         public ProfileManager(string profileDir)
         {
             ProfilesDir = profileDir;
+            ProfilesFile = Path.Combine(profileDir, _profilesFileName);
             SelectedProfile = new ProfileSelected();
             jsonSettings = new JsonSerializerSettings
             {
@@ -93,8 +95,8 @@ namespace ZenovaLauncher
 
         public void ImportProfiles()
         {
-            if (File.Exists(Path.Combine(ProfilesDir, _profilesFile)))
-                AddProfiles(LoadProfiles(File.ReadAllText(Path.Combine(ProfilesDir, _profilesFile))));
+            if (File.Exists(ProfilesFile))
+                AddProfiles(LoadProfiles(File.ReadAllText(ProfilesFile)));
             AddDefaultProfiles();
         }
 
@@ -125,8 +127,8 @@ namespace ZenovaLauncher
             //DirectoryInfo di = new DirectoryInfo(_profilesDir);
             //foreach (FileInfo file in di.EnumerateFiles()) file.Delete();
             //foreach (DirectoryInfo dir in di.EnumerateDirectories()) dir.Delete(true);
-            File.WriteAllText(Path.Combine(ProfilesDir, _profilesFile), JsonConvert.SerializeObject(InternalDictionary, Formatting.Indented, jsonSettings));
-            Utils.AddSecurityToFile(Path.Combine(ProfilesDir, _profilesFile));
+            File.WriteAllText(ProfilesFile, JsonConvert.SerializeObject(InternalDictionary, Formatting.Indented, jsonSettings));
+            Utils.AddSecurityToFile(ProfilesFile);
         }
 
         public class ProfileSelected : NotifyPropertyChangedBase

--- a/ZenovaLauncher/Utils/Preferences.cs
+++ b/ZenovaLauncher/Utils/Preferences.cs
@@ -50,10 +50,10 @@ namespace ZenovaLauncher
         }
 
 
-        public static void LoadPreferences(string dataDir)
+        public static void LoadPreferences()
         {
             Trace.WriteLine("Loading Preferences");
-            _preferencesFile = Path.Combine(dataDir, _preferencesFile);
+            _preferencesFile = Path.Combine(App.DataDirectory, _preferencesFile);
             jsonSettings = new JsonSerializerSettings { ContractResolver = new CamelCasePropertyNamesContractResolver() };
             if (File.Exists(_preferencesFile))
             {

--- a/ZenovaLauncher/Utils/ZenovaUpdater.cs
+++ b/ZenovaLauncher/Utils/ZenovaUpdater.cs
@@ -21,7 +21,6 @@ namespace ZenovaLauncher
         public static AssemblyType InstallerAssembly;
         public static AssemblyType ApiAssembly;
 
-        private string DataDirectory { get; set; }
         private GitHubClient Client { get; set; }
         private HttpClient DownloadClient { get; set; }
 
@@ -60,9 +59,8 @@ namespace ZenovaLauncher
 
         public ICommand CancelCommand { get; set; }
 
-        public ZenovaUpdater(string dataDirectory)
+        public ZenovaUpdater()
         {
-            DataDirectory = dataDirectory;
             Client = new GitHubClient(new ProductHeaderValue("ZenovaLauncher"));
             DownloadClient = new HttpClient();
             if (InstallerAssembly == null)
@@ -87,12 +85,12 @@ namespace ZenovaLauncher
                     Process.Start(psi);
                     await App.Current.Dispatcher.BeginInvoke(DispatcherPriority.Normal, (Action)delegate () { App.Current.Shutdown(); });
                 }, Assembly.GetEntryAssembly().GetName().Version);
-                ApiAssembly = new AssemblyType("ZenovaAPI", (type, assetNumber) => Path.Combine(DataDirectory, type.LatestRelease.Assets[assetNumber].Name),
+                ApiAssembly = new AssemblyType("ZenovaAPI", (type, assetNumber) => Path.Combine(App.DataDirectory, type.LatestRelease.Assets[assetNumber].Name),
                 async (dlPath) =>
                 {
                     if (dlPath.EndsWith(".zip"))
                     {
-                        string devPath = Path.Combine(DataDirectory, "dev");
+                        string devPath = Path.Combine(App.DataDirectory, "dev");
                         if (Directory.Exists(devPath))
                             Utils.Empty(devPath);
                         else
@@ -100,7 +98,7 @@ namespace ZenovaLauncher
                         await Task.Run(() => { ZipFile.ExtractToDirectory(dlPath, devPath); });
                         File.Delete(dlPath);
                     }
-                }, AssemblyType.GetVersionFromPath(Path.Combine(DataDirectory, "ZenovaAPI.dll")), 2);
+                }, AssemblyType.GetVersionFromPath(Path.Combine(App.DataDirectory, "ZenovaAPI.dll")), 2);
             }
             catch (Exception e)
             {


### PR DESCRIPTION
This PR fixes ZenovaAPI's file not getting the proper security permissions when a custom folder is specified (more should be done to cleanup the code that sets the permission but this is good for the time being. Also went ahead and redid some things that bothered me in a few files.