### PR TITLE
Disable mod loading on unsupported versions

### DIFF
--- a/ZenovaLauncher/Dialogs/EditProfileDialog.xaml.cs
+++ b/ZenovaLauncher/Dialogs/EditProfileDialog.xaml.cs
@@ -42,8 +42,16 @@ namespace ZenovaLauncher
             AvailableModsBox.ItemsSource = ModManager.instance.ToList();
             LoadedMods = profile.ModsList != null ? new ObservableCollection<Mod>(profile.ModsList) : new ObservableCollection<Mod>();
             LoadedModsBox.ItemsSource = LoadedMods;
-            FilterModsList();
-            ModOptionsExpander.IsEnabled = profile.Editable;
+
+            ModOptionsExpander.Visibility = Visibility.Collapsed;
+
+            if ((VersionBox.SelectedItem as MinecraftVersion).ModSupported)
+            {
+                FilterModsList();
+
+                if (profile.Editable)
+                    ModOptionsExpander.Visibility = Visibility.Visible;
+            }
         }
 
         public void RefreshMods()
@@ -54,6 +62,14 @@ namespace ZenovaLauncher
 
         private void VersionChanged(object sender, SelectionChangedEventArgs e)
         {
+            if (!(VersionBox.SelectedItem as MinecraftVersion).ModSupported)
+            {
+                ModOptionsExpander.Visibility = Visibility.Collapsed;
+                return;
+            }
+
+            ModOptionsExpander.Visibility = Visibility.Visible;
+
             RemoveUnsupportedMods();
             FilterModsList();
             RefreshMods();

--- a/ZenovaLauncher/Profiles/Profile.cs
+++ b/ZenovaLauncher/Profiles/Profile.cs
@@ -74,7 +74,7 @@ namespace ZenovaLauncher
         public bool Release => Version.Release;
         public bool Editable => Type == ProfileType.Custom;
         public bool Launching => ProfileLauncher.instance.LaunchedProfile == this;
-        public bool Modded => ModsList != null ? ModsList.Count > 0 : false;
+        public bool Modded => Version.ModSupported && ModsList != null && ModsList.Count > 0;
 
         public void UpdateLaunchStatus()
         {

--- a/ZenovaLauncher/Versions/MinecraftVersion.cs
+++ b/ZenovaLauncher/Versions/MinecraftVersion.cs
@@ -63,6 +63,22 @@ namespace ZenovaLauncher
         public string GameDirectory => Path.Combine(VersionManager.instance.VersionsDirectory, VersionName);
         public string PackageFamily => Preview ? MINECRAFT_PREVIEW_PACKAGE_FAMILY : MINECRAFT_PACKAGE_FAMILY;
         public bool IsInstalled => Directory.Exists(GameDirectory);
+        public bool ModSupported
+        {
+            get
+            {
+                // probably should be changed to a list but not gonna bother till we support more versions
+                var SupportedVersions = new System.Version(1, 14, 60, 5);
+
+                if (Beta || Version != SupportedVersions)
+                {
+                    return false;
+                }
+
+                return true;
+            }
+        }
+
         public void UpdateInstallStatus()
         {
             OnPropertyChanged("IsInstalled");


### PR DESCRIPTION
The only problem with this change is that currently the whitelist is using one version as a string, should probably be changed to a proper list 