### PR TITLE
Add security on update and use exception handling

### DIFF
--- a/ZenovaLauncher/Profiles/ProfileLauncher.cs
+++ b/ZenovaLauncher/Profiles/ProfileLauncher.cs
@@ -106,8 +106,20 @@ namespace ZenovaLauncher
                 }
                 if (p.Modded)
                 {
-                    // Ensure ZenovaAPI.dll has ALL APPLICATION PACKAGES security
-                    Utils.AddSecurityToFile(Path.Combine(App.DataDirectory, "ZenovaAPI.dll"));
+                    // Last attempt to get ZenovaAPI.dll the ALL_APPLICATION_PACKAGES security
+                    try
+                    {
+                        Utils.AddSecurityToFile(Path.Combine(App.DataDirectory, "ZenovaAPI.dll"));
+                    }
+                    catch (UnauthorizedAccessException)
+                    {
+                        Utils.ShowErrorDialog("Launch failed", "An error occured which prevented Zenova from launching Minecraft. Unable to add necessary permissions to ZenovaAPI.");
+                        return false;
+                    }
+                    catch (Exception)
+                    {
+                        throw;
+                    }
 
                     AppDebugger app = new AppDebugger(Utils.FindPackages(p.Version.PackageFamily).ToList()[0].Id.FullName);
                     if (app.GetPackageExecutionState() != PACKAGE_EXECUTION_STATE.PES_UNKNOWN)

--- a/ZenovaLauncher/Utils/ZenovaUpdater.cs
+++ b/ZenovaLauncher/Utils/ZenovaUpdater.cs
@@ -98,6 +98,11 @@ namespace ZenovaLauncher
                         await Task.Run(() => { ZipFile.ExtractToDirectory(dlPath, devPath); });
                         File.Delete(dlPath);
                     }
+                    else if (dlPath.EndsWith(".dll"))
+                    {
+                        // Ensure ZenovaAPI.dll has ALL_APPLICATION_PACKAGES security
+                        Utils.AddSecurityToFile(Path.Combine(App.DataDirectory, "ZenovaAPI.dll"));
+                    }
                 }, AssemblyType.GetVersionFromPath(Path.Combine(App.DataDirectory, "ZenovaAPI.dll")), 2);
             }
             catch (Exception e)


### PR DESCRIPTION
This should fix the remaining issues with adding permissions to the ZenovaAPI.dll however I've been unable to reproduce the issue I've had with the ALL_APPLICATION_PACKAGES being missing from the dll on launch