### PR TITLE
Handle xbox account edge cases

### DIFF
--- a/ZenovaLauncher/Profiles/AccountManager.cs
+++ b/ZenovaLauncher/Profiles/AccountManager.cs
@@ -15,14 +15,23 @@ namespace ZenovaLauncher
         public async Task AddAccounts()
         {
             Trace.WriteLine("AddAccounts");
+
+            // this registry entry should exist on new installs
             RegistryKey currentXboxReg = Registry.CurrentUser.OpenSubKey("SOFTWARE\\Microsoft\\XboxLive");
             if (currentXboxReg != null)
             {
-                var gamertag = currentXboxReg.GetValue("Gamertag");
-                var xuid = currentXboxReg.GetValue("Xuid");
+                object gamertag = currentXboxReg.GetValue("Gamertag");
+                object xuid = currentXboxReg.GetValue("Xuid");
                 if (gamertag != null && xuid != null)
+                {
                     Add(new XboxAccount(gamertag.ToString(), xuid.ToString()));
+                }
+                else 
+                { 
+                    Add(XboxAccount._null);
+                }
             }
+
             CurrentXboxAccount = this.First();
             Trace.WriteLine("AddAccounts finished");
         }
@@ -30,6 +39,8 @@ namespace ZenovaLauncher
 
     public class XboxAccount : NotifyPropertyChangedBase
     {
+        public static XboxAccount _null = new XboxAccount("<No account>", "");
+
         public XboxAccount(string gamertag, string xuid)
         {
             Gamertag = gamertag;

--- a/ZenovaLauncher/Utils/Preferences.cs
+++ b/ZenovaLauncher/Utils/Preferences.cs
@@ -43,10 +43,19 @@ namespace ZenovaLauncher
             get { return AccountManager.instance.CurrentXboxAccount.Gamertag; }
             set
             {
-                var current = AccountManager.instance.FirstOrDefault(a => a.Gamertag == value);
+                var manager = AccountManager.instance;
+                var current = manager.FirstOrDefault(a => a.Gamertag == value);
                 if (current != null)
                 {
-                    AccountManager.instance.CurrentXboxAccount = current;
+                    manager.CurrentXboxAccount = current;
+                }
+                else if (manager.First() != XboxAccount._null)
+                {
+                    manager.CurrentXboxAccount = manager.First();
+                }
+                else
+                {
+                    manager.CurrentXboxAccount = XboxAccount._null;
                 }
             }
         }


### PR DESCRIPTION
This solution creates a null XboxAccount which has the gamertag <No account> so that it can properly serialize and show up in our account list